### PR TITLE
Added a nix derivation, intended for the shell.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,14 @@
+let 
+  nixpkgs = (import <nixpkgs> {}).fetchgit {
+    url    = "git@github.com:zalora/nixpkgs.git";
+    rev    = "f8bd9e70fab91607caa9e3039f4059db77540a54";
+    sha256 = "3284674b4d7efd6290dce16837d1c67240aaae5f3d77b21e051f38faba6d7415";
+  };
+in
+{ system ? builtins.currentSystem
+, pkgs ? (import nixpkgs { inherit system; })
+, haskellPackages ? pkgs.haskellPackages_ghc783
+, src ? ./.
+, name ? "taggy"
+}: 
+haskellPackages.buildLocalCabal src name


### PR DESCRIPTION
Using `zalora/nixpkgs:HEAD`' to work around the (mysterious) `/homeless-shelter` bug, can substitute if this lands upstream.
