### PR TITLE
Needs GHC >= 7.6 due to use of LambdaCase

### DIFF
--- a/taggy.cabal
+++ b/taggy.cabal
@@ -55,7 +55,7 @@ library
                        Text.Taggy.Renderer
                        Text.Taggy.Types
   other-modules:   
-  build-depends:       base >=4.5 && <5,
+  build-depends:       base >=4.6 && <5,
                        blaze-html >= 0.7,
                        blaze-markup >= 0.6,
                        text >= 1,


### PR DESCRIPTION
I revised existing versions (https://hackage.haskell.org/package/taggy/revisions/) so a new release is only required if you wish to fix backwards compatibility.
