### PR TITLE
Allow specifying void tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can see this `domify` in action.
 
 ``` haskell
 λ> :set -XOverloadedStrings
-λ> head . domify . taggyWith False $ "<html><head></head><body>yo</body></html>"
+λ> head . domify . taggyWith def $ "<html><head></head><body>yo</body></html>"
 NodeElement (Element {eltName = "html", eltAttrs = fromList [], eltChildren = [NodeElement (Element {eltName = "head", eltAttrs = fromList [], eltChildren = []}),NodeElement (Element {eltName = "body", eltAttrs = fromList [], eltChildren = [NodeContent "yo"]})]})
 ```
 

--- a/example/taggy.hs
+++ b/example/taggy.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import Data.Attoparsec.Text.Lazy (eitherResult)
+import Data.Default
 import System.Environment
 import Text.Taggy
 
@@ -30,9 +31,9 @@ taggy fp = do
   content <- T.readFile fp
   either (\s -> putStrLn $ "couldn't parse: " ++ s) 
          (mapM_ print) 
-         (eitherResult $ run True content)
+         (eitherResult $ run def content)
 
 dom :: FilePath -> IO ()
 dom fp = do
   content <- T.readFile fp
-  mapM_ print . domify $ taggyWith True content
+  mapM_ print . domify $ taggyWith def content

--- a/src/Text/Taggy/DOM.hs
+++ b/src/Text/Taggy/DOM.hs
@@ -16,10 +16,11 @@
 
 module Text.Taggy.DOM where
 
+import Data.Default
 import Data.HashMap.Strict (HashMap)
 import Data.Monoid ((<>))
 import Data.Text (Text)
-import Text.Taggy.Parser (taggyWith)
+import Text.Taggy.Parser (taggyWith, ParseOptions)
 import Text.Taggy.Types
 
 import qualified Data.HashMap.Strict as HM
@@ -62,10 +63,10 @@ nodeChildren (NodeElement e) = eltChildren e
 --   to their corresponding unicode characters,
 --   just like in "Text.Taggy.Parser".
 --
---   > parseDOM convertEntities = domify . taggyWith cventities
-parseDOM :: Bool -> LT.Text -> [Node]
-parseDOM cventities =
-  domify . taggyWith cventities
+--   > parseDOM options = domify . taggyWith options
+parseDOM :: ParseOptions -> LT.Text -> [Node]
+parseDOM options =
+  domify . taggyWith options
 
 -- | Transform a list of tags (produced with 'taggyWith')
 --   into a list of toplevel nodes. If the document you're working

--- a/taggy.cabal
+++ b/taggy.cabal
@@ -1,5 +1,5 @@
 name:                taggy
-version:             0.2.1
+version:             0.3.0
 synopsis:            Efficient and simple HTML/XML parsing library
 description:         
   /taggy/ is a simple package for parsing HTML (and should work with XML)
@@ -58,6 +58,7 @@ library
   build-depends:       base >=4.6 && <5,
                        blaze-html >= 0.7,
                        blaze-markup >= 0.6,
+                       data-default >= 0.2,
                        text >= 1,
                        attoparsec >=0.11,
                        vector >=0.7,
@@ -71,6 +72,7 @@ executable taggy
   main-is:             taggy.hs
   hs-source-dirs:      example
   build-depends:       base >=4.5 && <5,
+                       data-default >= 0.2,
                        text >= 1,
                        attoparsec >=0.12,
                        taggy

--- a/taggy.cabal
+++ b/taggy.cabal
@@ -106,6 +106,7 @@ test-suite unit
   build-depends:
       base    == 4.*
     , blaze-html
+    , data-default
     , blaze-markup
     , text
     , hspec
@@ -129,6 +130,7 @@ test-suite integration
       base    == 4.*
     , blaze-html
     , blaze-markup
+    , data-default
     , directory
     , text
     , hspec >= 1.11


### PR DESCRIPTION
You might not want to use Data.Default, or provide helper functions for taggyWith/run/parseDOM that use defaults.

Fixes #12.