### PR TITLE
Handle implicitly closed tags in domify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-.stack-work/
+.stack-work
+.ghc.environment.*

--- a/src/Text/Taggy/DOM.hs
+++ b/src/Text/Taggy/DOM.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
 -- |
 -- Module       : Text.Taggy.DOM
 -- Copyright    : (c) 2014 Alp Mestanogullari, Vikram Verma
@@ -14,13 +17,25 @@
 -- This is especially useful when used in
 -- conjunction with <http://hackage.haskell.org/package/taggy-lens taggy-lens>
 
-module Text.Taggy.DOM where
+module Text.Taggy.DOM
+( AttrName
+, AttrValue
+, Element (..)
+, Node (..)
+, nodeChildren
+, parseDOM
+, domify
+, elemNode
+, convertText
+)
+where
 
 import Data.HashMap.Strict (HashMap)
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import Text.Taggy.Parser (taggyWith)
 import Text.Taggy.Types
+import Control.Applicative
 
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text.Lazy as LT
@@ -67,6 +82,7 @@ parseDOM :: Bool -> LT.Text -> [Node]
 parseDOM cventities =
   domify . taggyWith cventities
 
+-- | Helper function for building a 'HashMap' from a list of 'Attribute's
 attrMap :: [Attribute] -> HashMap Text Text
 attrMap attribs =
   HM.fromListWith (\v1 v2 -> v1 <> " " <> v2)
@@ -75,100 +91,259 @@ attrMap attribs =
   where
     attrToPair (Attribute k v) = (k, v)
 
+-- | Helper function to conveniently construct a 'NodeElement'
 elemNode :: Text -> [Attribute] -> [Node] -> Node
 elemNode name attribs children
   = NodeElement (Element name (attrMap attribs) children)
 
+-- | Helper function to conveniently construct a 'NodeContent'
+convertText :: Text -> Node
+convertText t = NodeContent t
+
+-- | Ad-hoc parser monad over a tag stream.
+--
+-- Essentially a state monad specialized over '[Tag]'.
+newtype Domify a = Domify { runDomify :: [Tag] -> ([Tag], a) }
+  deriving (Functor)
+
+instance Applicative Domify where
+  pure x =
+    Domify (\tags -> (tags, x))
+  liftA2 f (Domify a) (Domify b) =
+    Domify $ \tags ->
+      let (tags', x) = a tags
+          (tags'', y) = b tags'
+      in (tags'', f x y)
+      
+  
+instance Monad Domify where
+  Domify a >>= f = Domify $ \tags ->
+    let (tags', x) = a tags
+        Domify b = f x
+    in b tags'
+
+-- | Pop the next tag from the stream (consume). Returns 'Nothing' if the
+-- end of the stream has been reached.
+popTag :: Domify (Maybe Tag)
+popTag = Domify $ \case
+  [] -> ([], Nothing)
+  (t:tags) -> (tags, Just t)
+
+-- | Look at the next tag in the stream, but do not pop it off. Returns
+-- 'Nothing' if the end of the stream has been reached.
+peekTag :: Domify (Maybe Tag)
+peekTag = Domify $ \case
+  [] -> ([], Nothing)
+  tags@(t:_) -> (tags, Just t)
 
 -- | Transform a list of tags (produced with 'taggyWith')
 --   into a list of toplevel nodes. If the document you're working
 --   on is valid, there should only be one toplevel node, but let's
 --   not assume we're living in an ideal world.
 domify :: [Tag] -> [Node]
-domify [] =
-  []
-domify (TagOpen name attribs True : tags) =
-  elemNode name attribs [] : domify tags
-domify (TagText txt : tags) =
-  NodeContent txt : domify tags
-domify (TagOpen name attribs False : tags) =
-  elemNode name attribs children : domify unusedTags
+domify tags =
+  snd $ runDomify fetchToplevelNodes tags
+
+-- | Keep fetching 'Node's from the input stream until it is exhausted.
+fetchToplevelNodes :: Domify [Node]
+fetchToplevelNodes =
+  peekTag >>= \case
+    Nothing ->
+      pure []
+    Just _ -> do
+      mnode <- fetchNode []
+      case mnode of
+        Nothing ->
+          fetchToplevelNodes
+        Just node ->
+          (node :) <$> fetchToplevelNodes
+
+-- | Fetch one 'Node' from the input stream. Ancestory must be given in order
+-- to correctly close elements whose end tag has been omitted.
+fetchNode :: [Text] -- ^ Ancestors, closest first.
+          -> Domify (Maybe Node)
+fetchNode ancestors = do
+  popTag >>= \case
+    Nothing ->
+      pure Nothing -- end of input
+    Just tag -> case tag of
+      TagClose _ ->
+        pure Nothing
+      TagComment _ ->
+        pure Nothing
+      TagText txt ->
+        pure . Just $ convertText txt
+      TagOpen name attribs True ->
+        pure . Just $ elemNode name attribs []
+      TagOpen name attribs False -> do
+        children <- fetchChildren name ancestors
+        pure . Just $ elemNode name attribs children
+      TagScript (TagOpen name attribs _) scr _ ->
+        pure . Just $ elemNode name attribs [convertText scr]
+      TagScript _ scr _ ->
+        pure . Just $ elemNode "script" mempty [convertText scr]
+      TagStyle (TagOpen name attribs _) sty _ ->
+        pure . Just $ elemNode name attribs [convertText sty]
+      TagStyle _ sty _ ->
+        pure . Just $ elemNode "style" mempty [convertText sty]
+
+-- | Fetch all children of an element. The element context is specified via the
+-- current element's tag name and the ancestory chain (not including the
+-- current element). That is, @fetchChildren "p" ["section", "body", "html"]@
+-- fetches all the children of the @<div>@ element in the following HTML:
+-- @
+-- <html>
+--   <body>
+--     <section>
+--       <div>
+--         <h1>Hello</h1>
+--         <p>Hello, sailor! How's it going?</p>
+--       </div>
+--     </section>
+--   </body>
+-- </html>
+-- @
+-- Ancestory and current node must be known in order to correctly detect the
+-- end of the containing node if its end tag was omitted.
+fetchChildren :: Text -> [Text] -> Domify [Node]
+fetchChildren cur ancestors = do
+  peekTag >>= maybe (pure []) go
   where
-    (children, unusedTags) = untilClosed name ([], tags)
-domify (TagClose _ : tags) =
-  domify tags
-domify (TagComment _ : tags) =
-  domify tags
-domify (TagScript tago scr tagc : tags) =
-  domify $ [tago, TagText scr, tagc] ++ tags
-domify (TagStyle tago sty tagc : tags) =
-  domify $ [tago, TagText sty, tagc] ++ tags
+    -- End of document, closing shop
+    go (TagClose name)
+      | name == cur
+      = popTag >> pure []
+      | name `elem` ancestors
+      = pure []
+      | otherwise
+      = popTag >> fetchChildren cur ancestors
+    go (TagOpen name _ _)
+      | name `autoCloses` cur
+      = pure []
+    go _
+      = do
+          mchild <- fetchNode (cur : ancestors)
+          rest <- fetchChildren cur ancestors
+          pure $ maybe rest (:rest) mchild
 
-untilClosed :: Text -> ([Node], [Tag]) -> ([Node], [Tag])
-untilClosed name (cousins, TagClose n : ts)
-  | n == name = (cousins, ts)
-  | otherwise = untilClosed name ( cousins
-                                 , TagOpen n [] False
-                                 : TagClose n 
-                                 : ts )
+-- | Tells us which tags auto-close which elements. Tag name @a@ auto-closes
+-- an element with tag name @b@ iff @a `autoCloses` b@.
+autoCloses :: Text -> Text -> Bool
+autoCloses closer closee =
+  closer `elem` closersFor closee
 
-untilClosed name (cousins, TagText t : ts)
-  = let (cousins', ts') = untilClosed name (cousins, ts)
-        cousins''       = convertText t : cousins'
-    in (cousins++cousins'', ts')
+-- | Helper for implementing 'autoCloses' in a less tedious way.
+-- @closersFor a@ lists all tags @b@ for which @b `autoCloses` a@.
+closersFor :: Text -> [Text]
 
-untilClosed name (cousins, TagComment _ : ts)
-  = untilClosed name (cousins, ts)
+-- An li element’s end tag may be omitted if the li element is immediately
+-- followed by another li element or if there is no more content in the parent
+-- element.
+closersFor "li" = ["li"]
 
-untilClosed name (cousins, TagOpen n as True : ts)
-  = let (cousins', ts') = untilClosed name (cousins, ts)
-        elt             = Element n as' []
-        cousins''       = NodeElement elt : cousins'
-    in (cousins++cousins'', ts')
+-- A dt element’s end tag may be omitted if the dt element is immediately
+-- followed by another dt element or a dd element.
+closersFor "dt" = ["dt", "dd"]
 
-   where as' = HM.fromListWith (\v1 v2 -> v1 <> " " <> v2)
-             . map attrToPair $ as
+-- A dd element’s end tag may be omitted if the dd element is immediately
+-- followed by another dd element or a dt element, or if there is no more
+-- content in the parent element.
+closersFor "dd" = ["dt", "dd"]
 
-         attrToPair (Attribute k v) = (k, v)
+-- A p element’s end tag may be omitted if the p element is immediately
+-- followed by an address, article, aside, blockquote, details, div, dl,
+-- fieldset, figcaption, figure, footer, form, h1, h2, h3, h4, h5, h6, header,
+-- hr, main, nav, ol, p, pre, section, table, or ul element, or if there is no
+-- more content in the parent element and the parent element is an HTML element
+-- that is not an a, audio, del, ins, map, noscript, or video element, or an
+-- autonomous custom element.
+closersFor "p" =
+  [ "address"
+  , "article"
+  , "aside"
+  , "blockquote"
+  , "details"
+  , "div"
+  , "dl"
+  , "fieldset"
+  , "figcaption", "figure"
+  , "footer"
+  , "form"
+  , "h1", "h2", "h3", "h4", "h5", "h6"
+  , "header"
+  , "hr"
+  , "main"
+  , "nav"
+  , "ol", "ul"
+  , "p"
+  , "pre"
+  , "section"
+  , "table"
+  ]
 
-untilClosed name (cousins, TagOpen n as False : ts)
- = let (insideNew, ts') = untilClosed n ([], ts)
-       (cousins', ts'') = untilClosed name (cousins, ts')
-       elt              = Element n as' insideNew
-       cousins''        = NodeElement elt : cousins'
-   in (cousins'', ts'')
+-- An rt element’s end tag may be omitted if the rt element is immediately
+-- followed by an rt or rp element, or if there is no more content in the
+-- parent element.
+closersFor "rt" = ["rt", "rp"]
 
-   where as' = HM.fromListWith (\v1 v2 -> v1 <> " " <> v2)
-             . map attrToPair $ as
+-- An rp element’s end tag may be omitted if the rp element is immediately
+-- followed by an rt or rp element, or if there is no more content in the
+-- parent element.
+closersFor "rp" = ["rt", "rp"]
 
-         attrToPair (Attribute k v) = (k, v)
+-- An optgroup element’s end tag may be omitted if the optgroup element is
+-- immediately followed by another optgroup element, or if there is no more
+-- content in the parent element.
+closersFor "optgroup" = ["optgroup"]
 
-untilClosed name (cousins, TagScript tago scr _ : ts)
-  = let (TagOpen n at _) = tago
-        (cousins', ts')  = untilClosed name (cousins, ts)
-        cousins''        = NodeElement (Element n (at' at) [NodeContent scr]) : cousins'
-            
-    in (cousins++cousins'', ts')
+-- An option element’s end tag may be omitted if the option element is
+-- immediately followed by another option element, or if it is immediately
+-- followed by an optgroup element, or if there is no more content in the
+-- parent element.
+closersFor "option" = ["option", "optgroup"]
 
-   where at' at = HM.fromListWith (\v1 v2 -> v1 <> " " <> v2)
-                . map attrToPair $ at
+-- A colgroup element’s start tag may be omitted if the first thing inside the
+-- colgroup element is a col element, and if the element is not immediately
+-- preceded by another colgroup element whose end tag has been omitted. (It
+-- can’t be omitted if the element is empty.)
 
-         attrToPair (Attribute k v) = (k, v)
+-- A colgroup element’s end tag may be omitted if the colgroup element is not
+-- immediately followed by a space character or a comment.
 
-untilClosed name (cousins, TagStyle tago sty _ : ts)
-  = let (TagOpen n at _) = tago
-        (cousins', ts')  = untilClosed name (cousins, ts)
-        cousins''        = NodeElement (Element n (at' at) [NodeContent sty]) : cousins'
-            
-    in (cousins++cousins'', ts')
+-- A caption element’s end tag may be omitted if the caption element is not
+-- immediately followed by a space character or a comment.
 
-   where at' at = HM.fromListWith (\v1 v2 -> v1 <> " " <> v2)
-                . map attrToPair $ at
+-- A thead element’s end tag may be omitted if the thead element is immediately
+-- followed by a tbody or tfoot element.
+closersFor "thead" = ["tbody", "tfoot", "table"]
 
-         attrToPair (Attribute k v) = (k, v)
+-- A tbody element’s start tag may be omitted if the first thing inside the
+-- tbody element is a tr element, and if the element is not immediately
+-- preceded by a tbody, thead, or tfoot element whose end tag has been omitted.
+-- (It can’t be omitted if the element is empty.)
 
-untilClosed _ (cs, []) = (cs, [])
+-- A tbody element’s end tag may be omitted if the tbody element is immediately
+-- followed by a tbody or tfoot element, or if there is no more content in the
+-- parent element.
+closersFor "tbody" = ["tbody", "tfoot", "table"]
 
-convertText :: Text -> Node
-convertText t = NodeContent t
+-- A tfoot element’s end tag may be omitted if there is no more content in the
+-- parent element.
+
+-- A tr element’s end tag may be omitted if the tr element is immediately
+-- followed by another tr element, or if there is no more content in the parent
+-- element.
+closersFor "tr" = ["tr", "tbody", "table"]
+
+-- A td element’s end tag may be omitted if the td element is immediately
+-- followed by a td or th element, or if there is no more content in the parent
+-- element.
+closersFor "td" = ["td", "th", "tr", "tbody", "table"]
+
+-- A th element’s end tag may be omitted if the th element is immediately
+-- followed by a td or th element, or if there is no more content in the parent
+-- element.
+closersFor "th" = ["td", "th", "tr", "tbody", "table"]
+
+closersFor _ = []
 

--- a/src/Text/Taggy/Parser.hs
+++ b/src/Text/Taggy/Parser.hs
@@ -174,7 +174,7 @@ htmlWith cventities = go
                     (t:) `fmap` go
 
 tag :: Bool -> Parser Tag
-tag cventities = (skipSpace >> tagStructured cventities) <|> tagtext cventities
+tag cventities = tagStructured cventities <|> tagtext cventities
 
 tagStructured :: Bool -> Parser Tag
 tagStructured b =

--- a/taggy.cabal
+++ b/taggy.cabal
@@ -111,6 +111,8 @@ test-suite unit
     , vector
     , attoparsec
     , unordered-containers
+  other-modules:
+    Paths_taggy
   default-language:
       Haskell2010
 

--- a/taggy.cabal
+++ b/taggy.cabal
@@ -54,7 +54,6 @@ library
                        Text.Taggy.Parser,
                        Text.Taggy.Renderer
                        Text.Taggy.Types
-  other-modules:
   build-depends:       base >=4.6 && <5,
                        blaze-html >= 0.7,
                        blaze-markup >= 0.6,
@@ -98,11 +97,17 @@ test-suite unit
   ghc-options:
       -Wall -fno-warn-unused-do-bind
   hs-source-dirs:
-      src, tests/unit
+      tests/unit
   main-is:
       Spec.hs
+  other-modules:
+      Text.Taggy.DOMSpec
+    , Text.Taggy.EntitiesSpec
+    , Text.Taggy.ParserSpec
+    , Text.Taggy.RendererSpec
   build-depends:
       base    == 4.*
+    , taggy
     , blaze-html
     , blaze-markup
     , text
@@ -111,8 +116,6 @@ test-suite unit
     , vector
     , attoparsec
     , unordered-containers
-  other-modules:
-    Paths_taggy
   default-language:
       Haskell2010
 
@@ -122,11 +125,14 @@ test-suite integration
   ghc-options:
       -Wall -fno-warn-unused-do-bind
   hs-source-dirs:
-      src, tests/integration
+      tests/integration
   main-is:
       Main.hs
+  other-modules:
+      Paths_taggy
   build-depends:
       base    == 4.*
+    , taggy
     , blaze-html
     , blaze-markup
     , directory
@@ -136,7 +142,7 @@ test-suite integration
     , vector
     , attoparsec
     , unordered-containers
-  other-modules:
-    Paths_taggy
   default-language:
       Haskell2010
+
+-- vim:ts=2 sw=2

--- a/tests/unit/Text/Taggy/DOMSpec.hs
+++ b/tests/unit/Text/Taggy/DOMSpec.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Text.Taggy.DOMSpec where
+
+import Data.Attoparsec.Text.Lazy
+import Data.Text.Lazy
+import Test.Hspec
+import Text.Taggy.Parser
+import Text.Taggy.DOM
+import Text.Taggy.Types
+import Data.Monoid (mempty)
+
+spec :: Spec
+spec = do
+  describe "domify" $ do
+    it "domifies self-closing tags" $
+      [ TagOpen "br" [] True
+      , TagText "pizza"
+      ]
+      `domifiesTo`
+      [ NodeElement (Element "br" mempty [])
+      , NodeContent "pizza"
+      ]
+    it "domifies paired tags" $
+      [ TagOpen "p" [] False
+      , TagText "pizza"
+      , TagClose "p"
+      , TagText "olives"
+      ]
+      `domifiesTo`
+      [ NodeElement (Element "p" mempty [NodeContent "pizza"])
+      , NodeContent "olives"
+      ]
+    it "domifies implicitly closed <p>" $
+      [ TagOpen "p" [] False
+      , TagText "pizza"
+      , TagOpen "p" [] False
+      , TagText "olives"
+      ]
+      `domifiesTo`
+      [ NodeElement (Element "p" mempty [NodeContent "pizza"])
+      , NodeElement (Element "p" mempty [NodeContent "olives"])
+      ]
+    it "domifies implicitly closed <li>" $
+      [ TagOpen "ul" [] False
+      , TagOpen "li" [] False
+      , TagText "item 1"
+      , TagOpen "li" [] False
+      , TagText "item 2"
+      , TagClose "ul"
+      ]
+      `domifiesTo`
+      [ NodeElement (Element "ul" mempty
+          [ NodeElement (Element "li" mempty
+              [ NodeContent "item 1" ]
+          , NodeElement (Element "li" mempty
+              [ NodeContent "item 2" ]
+          ]
+      ]
+
+domifiesTo :: [Tag] -> [Node] -> Bool
+domifiesTo tags expected =
+  domify tags == expected

--- a/tests/unit/Text/Taggy/DOMSpec.hs
+++ b/tests/unit/Text/Taggy/DOMSpec.hs
@@ -2,13 +2,11 @@
 
 module Text.Taggy.DOMSpec where
 
-import Data.Attoparsec.Text.Lazy
-import Data.Text.Lazy
 import Test.Hspec
-import Text.Taggy.Parser
 import Text.Taggy.DOM
 import Text.Taggy.Types
 import Data.Monoid (mempty)
+import Data.Text (Text)
 
 spec :: Spec
 spec = do
@@ -18,8 +16,8 @@ spec = do
       , TagText "pizza"
       ]
       `domifiesTo`
-      [ NodeElement (Element "br" mempty [])
-      , NodeContent "pizza"
+      [ e "br" []
+      , text "pizza"
       ]
     it "domifies paired tags" $
       [ TagOpen "p" [] False
@@ -28,8 +26,24 @@ spec = do
       , TagText "olives"
       ]
       `domifiesTo`
-      [ NodeElement (Element "p" mempty [NodeContent "pizza"])
-      , NodeContent "olives"
+      [ e "p" [ text "pizza" ]
+      , text "olives"
+      ]
+    it "domifies omitted closing tags at end" $
+      [ TagOpen "p" [] False
+      , TagText "pizza"
+      ]
+      `domifiesTo`
+      [ e "p" [text "pizza"]
+      ]
+    it "closes tags when parent closes" $
+      [ TagOpen "p" [] False
+      , TagOpen "em" [] False
+      , TagText "pizza"
+      , TagClose "p"
+      ]
+      `domifiesTo`
+      [ e "p" [ e "em" [ text "pizza" ] ]
       ]
     it "domifies implicitly closed <p>" $
       [ TagOpen "p" [] False
@@ -38,8 +52,8 @@ spec = do
       , TagText "olives"
       ]
       `domifiesTo`
-      [ NodeElement (Element "p" mempty [NodeContent "pizza"])
-      , NodeElement (Element "p" mempty [NodeContent "olives"])
+      [ e "p" [text "pizza"]
+      , e "p" [text "olives"]
       ]
     it "domifies implicitly closed <li>" $
       [ TagOpen "ul" [] False
@@ -50,14 +64,39 @@ spec = do
       , TagClose "ul"
       ]
       `domifiesTo`
-      [ NodeElement (Element "ul" mempty
-          [ NodeElement (Element "li" mempty
-              [ NodeContent "item 1" ]
-          , NodeElement (Element "li" mempty
-              [ NodeContent "item 2" ]
+      [ e "ul"
+          [ e "li"
+              [ text "item 1" ]
+          , e "li"
+              [ text "item 2" ]
+          ]
+      ]
+    it "domifies implicitly closed <th>, <td>, <tr>" $
+      [ TagOpen "table" [] False
+      , TagOpen "tr" [] False
+      , TagOpen "th" [] False
+      , TagOpen "td" [] False
+      , TagOpen "td" [] False
+      , TagOpen "tr" [] False
+      , TagClose "table"
+      ]
+      `domifiesTo`
+      [ e "table"
+          [ e "tr"
+              [ e "th" []
+              , e "td" []
+              , e "td" []
+              ]
+          , e "tr" []
           ]
       ]
 
 domifiesTo :: [Tag] -> [Node] -> Bool
 domifiesTo tags expected =
   domify tags == expected
+
+e :: Text -> [Node] -> Node
+e tag children = NodeElement $ Element tag mempty children
+
+text :: Text -> Node
+text txt = NodeContent txt

--- a/tests/unit/Text/Taggy/ParserSpec.hs
+++ b/tests/unit/Text/Taggy/ParserSpec.hs
@@ -125,5 +125,20 @@ spec = do
                       , TagText "\n"
                       ]
 
+    it "retains whitespace between tags" $
+      "<br/> <br/>" ~> htmlWith False
+        `shouldParse` [ TagOpen "br" [] True
+                      , TagText " "
+                      , TagOpen "br" [] True
+                      ]
+
+    it "retains whitespace around text content" $
+      "<span>hello</span> world" ~> htmlWith False
+        `shouldParse` [ TagOpen "span" [] False
+                      , TagText "hello"
+                      , TagClose "span"
+                      , TagText " world"
+                      ]
+
 (~>) :: Text -> Parser a -> Either String a
 (~>) = (Test.Hspec.Attoparsec.Source.~>)


### PR DESCRIPTION
This makes taggy domify HTML with implicitly closed tags correctly, e.g.:

```html
<ul>
  <li>List item
  <li>Another list item
</ul>
```