### PR TITLE
Fix invalid rendering of void elements like br

### DIFF
--- a/src/Text/Taggy/Renderer.hs
+++ b/src/Text/Taggy/Renderer.hs
@@ -47,7 +47,6 @@ instance AsMarkup Element where
   toMarkup convertEntities Element{..} = eltAttrs `toAttribute` Parent tag begin end kids
     where tag   = toStatic eltName
           begin = toStatic $ "<" <> eltName
-          end   = toStatic $ "</" <> eltName <> ">"
           end   = case eltName of
                     "br" -> toStatic ""
                     _ -> toStatic $ "</" <> eltName <> ">"

--- a/src/Text/Taggy/Renderer.hs
+++ b/src/Text/Taggy/Renderer.hs
@@ -48,6 +48,9 @@ instance AsMarkup Element where
     where tag   = toStatic eltName
           begin = toStatic $ "<" <> eltName
           end   = toStatic $ "</" <> eltName <> ">"
+          end   = case eltName of
+                    "br" -> toStatic ""
+                    _ -> toStatic $ "</" <> eltName <> ">"
           kids  = foldMap (toMarkup convertEntities) eltChildren
 
 class Renderable a where

--- a/taggy.cabal
+++ b/taggy.cabal
@@ -60,6 +60,7 @@ library
                        text >= 1,
                        attoparsec >=0.11,
                        vector >=0.7,
+                       containers,
                        unordered-containers >= 0.2
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
Many browsers treat the current rendering `<br></br>` as a pair of `<br>`.   The standard says these close tags are not permitted.